### PR TITLE
Nahuhh patch rc1

### DIFF
--- a/src/full-monero-node-external-sd-install.sh
+++ b/src/full-monero-node-external-sd-install.sh
@@ -41,12 +41,10 @@ fi
 
 termux-wake-lock -y
 pkg update -y
-pkg upgrade -y
 pkg install nano wget termux-api jq -y
 
-
-# Cleanup
-rm -f $TERMUX_BOOT/before_start_monero_node
+# Pre-Clean  (commented as it seems to not be used)
+# rm -f $TERMUX_BOOT/before_start_monero_node
 
 
 # Create Directories
@@ -57,56 +55,56 @@ mkdir -p $TERMUX_SHORTCUTS
 mkdir -p $TERMUX_SCHEDULED
 mkdir -p $NODE_CONFIG
 
+
 # Download Blocklist
 cd $NODE_CONFIG
-wget https://gui.xmr.pm/files/block.txt
-
+wget -O block.txt https://gui.xmr.pm/files/block.txt
 # Create Monerod Config file
  cat << EOF > config.txt
 # Data directory (blockchain db and indices)
-data-dir=$NODE_DATA
+	data-dir=$NODE_DATA
 
 # Log file
-log-file=/dev/null
-max-log-file-size=0       # Prevent monerod from creating log files
+	log-file=/dev/null
+	max-log-file-size=0       # Prevent monerod from creating log files
 
 #Peer ban list
-ban-list=$NODE_CONFIG/block.txt
+	ban-list=$NODE_CONFIG/block.txt
 
 # block-sync-size=50
 # prune-blockchain=1             #Uncomment to prune
 
-# P2P (seedind) binds
-   p2p-bind-ip=0.0.0.0          # Bind to all interfaces. Default is local 127.0.0.1
-   p2p-bind-port=18080          # Bind to default port
+# P2P (seeding) binds
+	p2p-bind-ip=0.0.0.0          # Bind to all interfaces. Default is local 127.0.0.1
+	p2p-bind-port=18080          # Bind to default port
 
 # Restricted RPC binds (allow restricted access)
 # Uncomment below for access to the node from LAN/WAN. May require port forwarding for WAN access
-   rpc-restricted-bind-ip=0.0.0.0
-   rpc-restricted-bind-port=18089
+	rpc-restricted-bind-ip=0.0.0.0
+	rpc-restricted-bind-port=18089
 
 # Unrestricted RPC binds
-   rpc-bind-ip=127.0.0.1         # Bind to local interface. Default = 127.0.0.1
-   rpc-bind-port=18081           # Default = 18081
-  # confirm-external-bind=1       # Open node (confirm). Required if binding outside of localhost  
-  # restricted-rpc=1              # Prevent unsafe RPC calls.
+	rpc-bind-ip=127.0.0.1         # Bind to local interface. Default = 127.0.0.1
+	rpc-bind-port=18081           # Default = 18081
+	#confirm-external-bind=1       # Open node (confirm). Required if binding outside of localhost  
+	#restricted-rpc=1              # Prevent unsafe RPC calls.
 
-   no-zmq=1
-   no-igd=1                         # Disable UPnP port mapping
-   db-sync-mode=safe                # Slow but reliable db writes
+  	no-zmq=1
+	no-igd=1                         # Disable UPnP port mapping
+	db-sync-mode=safe                # Slow but reliable db writes
 
 # Emergency checkpoints set by MoneroPulse operators will be enforced to workaround potential consensus bugs
 # Check https://monerodocs.org/infrastructure/monero-pulse/ for explanation and trade-offs
-   # enforce-dns-checkpointing=1
-    disable-dns-checkpoints=1
-    enable-dns-blocklist=1
+	#enforce-dns-checkpointing=1
+	disable-dns-checkpoints=1
+	enable-dns-blocklist=1
 
 
 # Connection Limits
-    out-peers=32              # This will enable much faster sync and tx awareness; the default 8 is suboptimal nowadays
-    in-peers=100            # The default is unlimited; we prefer to put a cap on this
-    limit-rate-up=1048576     # 1048576 kB/s == 1GB/s; a raise from default 2048 kB/s; contribute more to p2p network
-    limit-rate-down=1048576   # 1048576 kB/s == 1GB/s; a raise from default 8192 kB/s; allow for faster initial sync
+	out-peers=32              # This will enable much faster sync and tx awareness; the default 8 is suboptimal nowadays
+	in-peers=100            # The default is unlimited; we prefer to put a cap on this
+	limit-rate-up=1048576     # 1048576 kB/s == 1GB/s; a raise from default 2048 kB/s; contribute more to p2p network
+	limit-rate-down=1048576   # 1048576 kB/s == 1GB/s; a raise from default 8192 kB/s; allow for faster initial sync
 EOF
 
 # Create Scripts
@@ -191,8 +189,8 @@ func_xmrnode_install(){
 	mv monero-a* $MONERO_CLI
 
         # Download Blocklist
-        cd $NODE_CONFIG
-        wget https://gui.xmr.pm/files/block.txt
+	cd $NODE_CONFIG
+	wget -O block.txt https://gui.xmr.pm/files/block.txt
 	cd $TERMUX_SHORTCUTS
 	termux-toast -g bottom "Starting XMR Node.."
 	./Start\ XMR\ Node
@@ -301,7 +299,7 @@ cp Update\ XMR\ Node $TERMUX_SCHEDULED
 cd $TERMUX_SHORTCUTS
 ./Stop\ XMR\ Node && echo "Monero Node Stopped"
 cd
-wget -O monero.tar.bzip2 $MONERO_CLI_URL
+wget -c -O monero.tar.bzip2 $MONERO_CLI_URL
 tar jxvf monero.tar.bzip2
 rm monero.tar.bzip2
 rm -rf $MONERO_CLI
@@ -327,5 +325,7 @@ echo "   To do this: go to your router settings (usually 192.168.0.1 in your bro
 echo "   Find 'Port Forwarding' and forward public/external port 18080 to internal/private port 18080, setting the internal ip to:"
 termux-wifi-connectioninfo
 echo "Tip: If you want to enable Wallet access from WAN, Also forward 18089 to 18089 as well)"
-"Cheers ☠"
+echo "to make changes to the config file:"
+echo "nano $NODE_CONFIG/config.txt"
+echo "Cheers ☠"
 )

--- a/src/full-monero-node-external-sd-install.sh
+++ b/src/full-monero-node-external-sd-install.sh
@@ -260,7 +260,6 @@ then
 	RESP=\$(termux-dialog radio -t "Delete blockchain data?" -v "Yes,No" | jq '.index')
 
 	#0 = Uninstall
-
 	if [ \$RESP = 0 ]
 	then
         echo "Deleting blockchain data"
@@ -319,13 +318,14 @@ echo    "make sure to install Termux:Boot from f-droid, and run it once."
 echo "3. If behind a router and youd like to access your node from other devices, go to:"
 echo "   android settings > wifi > edit saved network > advanced > DHCP"
 echo "   change from automatic to manual, and set the IP to:"
-termux-wifi-connectioninfo
+echo $(termux-wifi-connectioninfo | jq '.ip')
 echo "4. Idealky, you *should* also enable P2P seeding."
 echo "   To do this: go to your router settings (usually 192.168.0.1 in your browser)"
 echo "   Find 'Port Forwarding' and forward public/external port 18080 to internal/private port 18080, setting the internal ip to:"
-termux-wifi-connectioninfo
-echo "Tip: If you want to enable Wallet access from WAN, Also forward 18089 to 18089 as well)"
-echo "to make changes to the config file:"
+echo $(termux-wifi-connectioninfo | jq '.ip')
+echo "4b. To enable Wallet access from WAN:"
+echo "Also forward 18089 to 18089 as well"
+echo "5. To make changes to the config file:"
 echo "nano $NODE_CONFIG/config.txt"
 echo "Cheers ☠"
 )

--- a/src/full-monero-node-external-sd-install.sh
+++ b/src/full-monero-node-external-sd-install.sh
@@ -314,12 +314,12 @@ sleep 1
 echo "A couple things for you to do:"
 echo "1. Add the Termux:Widget to your homescreen"
 echo "2. If youd like the node to run automatically on boot"
-echo    "make sure to install Termux:Boot from f-droid, and run it once."
+echo "   make sure to install Termux:Boot from f-droid, and run it once."
 echo "3. If behind a router and youd like to access your node from other devices, go to:"
 echo "   android settings > wifi > edit saved network > advanced > DHCP"
 echo "   change from automatic to manual, and set the IP to:"
 echo $(termux-wifi-connectioninfo | jq '.ip')
-echo "4. Idealky, you *should* also enable P2P seeding."
+echo "4. Ideally, you *should* also enable P2P seeding."
 echo "   To do this: go to your router settings (usually 192.168.0.1 in your browser)"
 echo "   Find 'Port Forwarding' and forward public/external port 18080 to internal/private port 18080, setting the internal ip to:"
 echo $(termux-wifi-connectioninfo | jq '.ip')

--- a/src/full-monero-node-external-sd-install.sh
+++ b/src/full-monero-node-external-sd-install.sh
@@ -1,8 +1,10 @@
 #!/data/data/com.termux/files/usr/bin/sh
 
 (
-MONERO_CLI=~/monero-cli
+MONERO=~/monero-cli
+MONERO_CLI=~/monero-cli/monero-cli
 NODE_DATA=~/storage/external-1/bitmonero
+NODE_CONFIG=~/monero-cli/config
 TERMUX_BOOT=~/.termux/boot
 TERMUX_SHORTCUTS=~/.shortcuts
 TERMUX_SCHEDULED=~/termux-scheduled
@@ -18,8 +20,8 @@ case $(uname -m) in
 	*) termux-toast -g bottom "Your device is not compatible- must be ARMv7 or v8"; exit 1 ;;
 esac
 
-# Setup
 
+# Preconfigure
 termux-setup-storage
 
 RESP=$(termux-dialog confirm -t "XMR Node" -i \
@@ -27,8 +29,9 @@ RESP=$(termux-dialog confirm -t "XMR Node" -i \
 
 Make sure you have these apps installed (via F-Droid) before proceeding:
 
- 	- Termux Boot
 	- Termux Widget
+	- Termux API
+ 	- Termux Boot (optional. required for start-on-boot)
 
 Are you ready to continue?" | jq '.text')
 if [ "$RESP" = '"no"' ]
@@ -38,29 +41,82 @@ fi
 
 termux-wake-lock -y
 pkg update -y
-pkg install wget termux-api jq -y
+pkg upgrade -y
+pkg install nano wget termux-api jq -y
+
 
 # Cleanup
-
 rm -f $TERMUX_BOOT/before_start_monero_node
 
-# Dirs
 
+# Create Directories
 mkdir -p $MONERO_CLI
 mkdir -p $NODE_DATA
 mkdir -p $TERMUX_BOOT
-mkdir -p $TERMUX_SHORTCUTS 
-mkdir -p $TERMUX_SCHEDULED 
+mkdir -p $TERMUX_SHORTCUTS
+mkdir -p $TERMUX_SCHEDULED
+mkdir -p $NODE_CONFIG
 
-# Scripts
+# Download Blocklist
+cd $NODE_CONFIG
+wget https://gui.xmr.pm/files/block.txt
 
+# Create Monerod Config file
+ cat << EOF > config.txt
+# Data directory (blockchain db and indices)
+data-dir=$NODE_DATA
+
+# Log file
+log-file=/dev/null
+max-log-file-size=0       # Prevent monerod from creating log files
+
+#Peer ban list
+ban-list=$NODE_CONFIG/block.txt
+
+# block-sync-size=50
+# prune-blockchain=1             #Uncomment to prune
+
+# P2P (seedind) binds
+   p2p-bind-ip=0.0.0.0          # Bind to all interfaces. Default is local 127.0.0.1
+   p2p-bind-port=18080          # Bind to default port
+
+# Restricted RPC binds (allow restricted access)
+# Uncomment below for access to the node from LAN/WAN. May require port forwarding for WAN access
+   rpc-restricted-bind-ip=0.0.0.0
+   rpc-restricted-bind-port=18089
+
+# Unrestricted RPC binds
+   rpc-bind-ip=127.0.0.1         # Bind to local interface. Default = 127.0.0.1
+   rpc-bind-port=18081           # Default = 18081
+  # confirm-external-bind=1       # Open node (confirm). Required if binding outside of localhost  
+  # restricted-rpc=1              # Prevent unsafe RPC calls.
+
+   no-zmq=1
+   no-igd=1                         # Disable UPnP port mapping
+   db-sync-mode=safe                # Slow but reliable db writes
+
+# Emergency checkpoints set by MoneroPulse operators will be enforced to workaround potential consensus bugs
+# Check https://monerodocs.org/infrastructure/monero-pulse/ for explanation and trade-offs
+   # enforce-dns-checkpointing=1
+    disable-dns-checkpoints=1
+    enable-dns-blocklist=1
+
+
+# Connection Limits
+    out-peers=32              # This will enable much faster sync and tx awareness; the default 8 is suboptimal nowadays
+    in-peers=100            # The default is unlimited; we prefer to put a cap on this
+    limit-rate-up=1048576     # 1048576 kB/s == 1GB/s; a raise from default 2048 kB/s; contribute more to p2p network
+    limit-rate-down=1048576   # 1048576 kB/s == 1GB/s; a raise from default 8192 kB/s; allow for faster initial sync
+EOF
+
+# Create Scripts
 cd $TERMUX_SHORTCUTS
 
-  cat << EOF > Start\ XMR\ Node 
+  cat << EOF > Start\ XMR\ Node
 #!/data/data/com.termux/files/usr/bin/sh
 termux-wake-lock
 cd $MONERO_CLI
-./monerod --data-dir $NODE_DATA --db-sync-mode safe:sync --enable-dns-blocklist --in-peers 10 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18089 --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18081 --no-igd --no-zmq --detach
+./monerod --config-file $NODE_CONFIG/config.txt --detach
 sleep 10
 
 cp $TERMUX_SHORTCUTS/Start\ XMR\ Node $TERMUX_BOOT
@@ -73,7 +129,7 @@ EOF
  cat << EOF > Stop\ XMR\ Node
 #!/data/data/com.termux/files/usr/bin/sh
 cd $MONERO_CLI
-./monerod exit && tail --pid=$(pidof monerod) -f /dev/null && echo 'Exited' 
+./monerod exit && tail --pid=\$(pidof monerod) -f /dev/null && echo 'Exited' 
 rm -f $TERMUX_BOOT/Start\ XMR\ Node
 
 termux-wake-unlock
@@ -89,14 +145,15 @@ EOF
 #!/data/data/com.termux/files/usr/bin/sh
 cd $MONERO_CLI
 ./monerod status
-sleep 10
+sleep 3
+./moderod print_net_stats
+sleep 7
 cd $TERMUX_SCHEDULED
 ./xmr_notifications
 EOF
 
  cat << "EOF" > xmr_notifications
 #!/data/data/com.termux/files/usr/bin/sh
-
 REQ=$(curl -s http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json')
 
 if [ "$REQ" ]
@@ -113,17 +170,17 @@ then
 	STORAGE_REMAINING=$(printf %.1f $(echo "$DATA" | jq '.free_space * 0.000000001'))
 	LOCAL_IP=$(echo $(termux-wifi-connectioninfo | jq '.ip') | tr -d '"')
 
-	NOTIFICATION=$(printf '%s\n' "⛓️ XMR-$VERSION" "🕐️ Running Since: $DATE" "🔄 Sync Progress: $SYNC_STATUS %" "📤️ OUT: $OUTGOING_CONNECTIONS / 🌱 P2P: $P2P_CONNECTIONS / 📲 RPC: $RPC_CONNECTIONS" "💾 Free Space: $STORAGE_REMAINING GB" "$UPDATE_AVAILABLE" "🔌 Local IP: ${LOCAL_IP}:18089")
+	NOTIFICATION=$(printf '%s\n' "⛓️ XMR-$VERSION" "🕐️ Running Since: $DATE" "🔄 Sync Progress: $SYNC_STATUS %" "📤️ OUT: $OUTGOING_CONNECTIONS / 🌱 P2P: $P2P_CONNECTIONS / 📲 RPC: $RPC_CONNECTIONS" "💾 Free Space: $STORAGE_REMAINING GB" "🔌 Local IP: ${LOCAL_IP}:18089" "$UPDATE_AVAILABLE" )
 else
-	NODE_ONLINE="🔴 XMR Node Offline"
+	NODE_ONLINE="🔴 XMR Node Offline!"
 	NOTIFICATION="RPC Error: Turn on your Node!"
 fi
 termux-notification -i monero -c "$NOTIFICATION"  -t "$NODE_ONLINE" --ongoing --priority low --alert-once
 EOF
 
+
  cat << EOF > Update\ XMR\ Node
 #!/data/data/com.termux/files/usr/bin/sh
-
 func_xmrnode_install(){
 	./Stop\ XMR\ Node && echo "Monero Node Stopped"
 	cd
@@ -132,6 +189,10 @@ func_xmrnode_install(){
 	rm monero.tar.bzip2
 	rm -rf $MONERO_CLI
 	mv monero-a* $MONERO_CLI
+
+        # Download Blocklist
+        cd $NODE_CONFIG
+        wget https://gui.xmr.pm/files/block.txt
 	cd $TERMUX_SHORTCUTS
 	termux-toast -g bottom "Starting XMR Node.."
 	./Start\ XMR\ Node
@@ -173,8 +234,10 @@ fi
 
 EOF
 
+
+
  cat << EOF > Uninstall\ XMR\ Node
-#!/data/data/com.termux/files/usr/bin/sh
+#!/data/data/com.termux/files/usr/bin/bash
 RESP=\$(termux-dialog confirm -t "Uninstall XMR Node" -i "Do you wish to remove XMR node and all its associated files? (deleting the blockchain remains optional)" | jq '.text')
 #1 = Uninstall
 if [ \$RESP = '"yes"' ]
@@ -190,24 +253,38 @@ then
 	rm -f XMR\ Node\ Status
 	rm -rf $MONERO_CLI
 
-	cd $HOME/termux-scheduled
+	cd $TERMUX_SCHEDULED
 	rm -f xmr_notifications
 	rm -f Update\ XMR\ Node
 
-	cd $HOME/.shortcuts
+	cd $TERMUX_SHORTCUTS
+
 	RESP=\$(termux-dialog radio -t "Delete blockchain data?" -v "Yes,No" | jq '.index')
 
-	#1 = Uninstall
+	#0 = Uninstall
 
-	if [ \$RESP == 1 ]
+	if [ \$RESP = 0 ]
 	then
-		rm -rf $NODE_DATA
-	fi
+        echo "Deleting blockchain data"
+	rm -rf $NODE_DATA
+        fi
+
+
+	RESP=\$(termux-dialog radio -t "Delete config file and uninstall script?" -v "Yes,No" | jq '.index')
+	#0 = Uninstall
+	if [ \$RESP = 0 ]
+	then
+        echo "Deleting config file"
+	rm -rf $MONERO
 	rm -rf Uninstall\ XMR\ Node
+	fi
 	exit 1
 fi
+
 EOF
 
+
+# Finish Setting Up
 chmod +x Start\ XMR\ Node
 chmod +x Stop\ XMR\ Node
 chmod +x Update\ XMR\ Node
@@ -219,11 +296,11 @@ cp Start\ XMR\ Node $TERMUX_BOOT
 mv xmr_notifications $TERMUX_SCHEDULED
 cp Update\ XMR\ Node $TERMUX_SCHEDULED
 
-# Start
 
+# Start
 cd $TERMUX_SHORTCUTS
 ./Stop\ XMR\ Node && echo "Monero Node Stopped"
-cd 
+cd
 wget -O monero.tar.bzip2 $MONERO_CLI_URL
 tar jxvf monero.tar.bzip2
 rm monero.tar.bzip2
@@ -232,5 +309,23 @@ mv monero-a* $MONERO_CLI
 cd $TERMUX_SHORTCUTS
 ./Start\ XMR\ Node
 
-echo "Done! 👍"
+echo "I'm Done! 👍."
+echo "..."
+sleep 2
+echo "But.."
+sleep 1
+echo "A couple things for you to do:"
+echo "1. Add the Termux:Widget to your homescreen"
+echo "2. If youd like the node to run automatically on boot"
+echo    "make sure to install Termux:Boot from f-droid, and run it once."
+echo "3. If behind a router and youd like to access your node from other devices, go to:"
+echo "   android settings > wifi > edit saved network > advanced > DHCP"
+echo "   change from automatic to manual, and set the IP to:"
+termux-wifi-connectioninfo
+echo "4. Idealky, you *should* also enable P2P seeding."
+echo "   To do this: go to your router settings (usually 192.168.0.1 in your browser)"
+echo "   Find 'Port Forwarding' and forward public/external port 18080 to internal/private port 18080, setting the internal ip to:"
+termux-wifi-connectioninfo
+echo "Tip: If you want to enable Wallet access from WAN, Also forward 18089 to 18089 as well)"
+"Cheers ☠"
 )

--- a/src/full-monero-node-external-sd-install.sh
+++ b/src/full-monero-node-external-sd-install.sh
@@ -260,6 +260,7 @@ then
 	RESP=\$(termux-dialog radio -t "Delete blockchain data?" -v "Yes,No" | jq '.index')
 
 	#0 = Uninstall
+
 	if [ \$RESP = 0 ]
 	then
         echo "Deleting blockchain data"
@@ -314,18 +315,17 @@ sleep 1
 echo "A couple things for you to do:"
 echo "1. Add the Termux:Widget to your homescreen"
 echo "2. If youd like the node to run automatically on boot"
-echo "   make sure to install Termux:Boot from f-droid, and run it once."
+echo    "make sure to install Termux:Boot from f-droid, and run it once."
 echo "3. If behind a router and youd like to access your node from other devices, go to:"
 echo "   android settings > wifi > edit saved network > advanced > DHCP"
 echo "   change from automatic to manual, and set the IP to:"
-echo $(termux-wifi-connectioninfo | jq '.ip')
-echo "4. Ideally, you *should* also enable P2P seeding."
+termux-wifi-connectioninfo
+echo "4. Idealky, you *should* also enable P2P seeding."
 echo "   To do this: go to your router settings (usually 192.168.0.1 in your browser)"
 echo "   Find 'Port Forwarding' and forward public/external port 18080 to internal/private port 18080, setting the internal ip to:"
-echo $(termux-wifi-connectioninfo | jq '.ip')
-echo "4b. To enable Wallet access from WAN:"
-echo "Also forward 18089 to 18089 as well"
-echo "5. To make changes to the config file:"
+termux-wifi-connectioninfo
+echo "Tip: If you want to enable Wallet access from WAN, Also forward 18089 to 18089 as well)"
+echo "to make changes to the config file:"
 echo "nano $NODE_CONFIG/config.txt"
 echo "Cheers ☠"
 )


### PR DESCRIPTION
- Fixed $(pidof monerod) on exit
- Added config file
Edit config if you need to change options. 
Located at ~/monero-cli/config/config.txt
- Added: download ban list during install and node update
- Added: instructions for port forwarding and disabling auto ip assignment via DHCP 
- Small changes to uninstall (prompt to delete config file and uninstall file)
- Switch uninstall file from sh to bash, to get rid of the errors in terminal